### PR TITLE
Update indexer to a v0.4.0 working state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 data/
 postgres_data/
-allora-cosmos-pump
+allora-indexer
 pump
 allorad
 vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM golang:1.22-bookworm AS gobuilder
-ADD . /src
+
 WORKDIR /src
+
+# Copy go.mod and go.sum files first to leverage caching
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+COPY . .
 RUN go build .
 
 # final image
@@ -26,12 +34,12 @@ RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/ap
 
 # Detect the architecture and download the appropriate binary
 ARG TARGETARCH="amd64"
-RUN mkdir -p /usr/local/bin/previous/v2 && \
-    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.2.14/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v2/allorad; \
-    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
+RUN mkdir -p /usr/local/bin/previous/v3 && \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v3/allorad; \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.4.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
     chmod -R 777 /usr/local/bin/allorad && \
-    chmod -R 777 /usr/local/bin/previous/v2/allorad
+    chmod -R 777 /usr/local/bin/previous/v3/allorad
 
-COPY --from=gobuilder /src/allora-cosmos-pump /usr/local/bin/allora-cosmos-pump
+COPY --from=gobuilder /src/allora-indexer /usr/local/bin/allora-indexer
 # EXPOSE 8080
-ENTRYPOINT ["allora-cosmos-pump"]
+ENTRYPOINT ["allora-indexer"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-  provider:
+  indexer:
     build:
       context: .
       dockerfile: Dockerfile
@@ -25,6 +25,8 @@ services:
       - --S3_BUCKET_NAME=${S3_BUCKET_NAME}
       - --S3_FILE_KEY=${S3_FILE_KEY}
       - --MODE=${MODE}
+      - --BOOTSTRAP_BLOCKHEIGHT=${BOOTSTRAP_BLOCKHEIGHT}
+      - --MAX_CONCURRENT_TX_PROCESSING=${MAX_CONCURRENT_TX_PROCESSING}
 
 volumes:
   postgres_data:

--- a/execute.go
+++ b/execute.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/allora-network/allora-cosmos-pump/types"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/allora-network/allora-indexer/types"
+	"github.com/rs/zerolog/log"
 )
 
 func ExecuteCommand(cliApp, node string, parts []string) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/allora-network/allora-cosmos-pump
+module github.com/allora-network/allora-indexer
 
 go 1.22
 

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Define the application name
-APP_NAME="allora-cosmos-pump"
+APP_NAME="allora-indexer"
 
 # Check for a version argument, otherwise set a default version
 VERSION=${1:-"v0.0.1"}
 
 # Define the base URL using the specified or default version
-BASE_URL="https://github.com/allora-network/allora-cosmos-pump/releases/download/$VERSION"
+BASE_URL="https://github.com/allora-network/allora-indexer/releases/download/$VERSION"
 
 # Determine the operating system and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/process_block.go
+++ b/process_block.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
-
 
 func getLatestHeight() (uint64, error) {
 	blockInfo, err := ExecuteCommandByKey[types.BlockInfo](config, "latestBlock")
@@ -27,7 +26,7 @@ func getLatestHeight() (uint64, error) {
 	return uint64(latestHeight), nil
 }
 
-func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error){
+func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error) {
 	// Convert height to string
 	heightStr := strconv.FormatUint(height, 10)
 
@@ -59,7 +58,7 @@ func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error){
 	// processBlockQuery(config, blockQuery)
 }
 
-func writeBlock(config ClientConfig, blockQuery types.BlockQuery) (error) {
+func writeBlock(config ClientConfig, blockQuery types.BlockQuery) error {
 	// Process the block information (e.g., insert into database)
 	// Assuming `insertBlockInfo` is defined elsewhere
 	height, err := strconv.ParseUint(blockQuery.Header.Height, 10, 64)

--- a/process_consensus.go
+++ b/process_consensus.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
 

--- a/process_events_test.go
+++ b/process_events_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFilterEvents(t *testing.T) {
+	whitelist := map[string]EventProcessing{
+		"EventScoresSet":      {Type: ScoreEvent},
+		"EventRewardsSettled": {Type: RewardEvent},
+		"EventNetworkLossSet": {Type: NetworkLossEvent},
+	}
+
+	tests := []struct {
+		name     string
+		events   *BlockResult
+		expected []Event
+	}{
+		{
+			name: "All events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.EventScoresSet"},
+						{Type: "emissions.v1.EventRewardsSettled"},
+						{Type: "emissions.v1.EventNetworkLossSet"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v2.EventScoresSet"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v1.EventScoresSet"},
+				{Type: "emissions.v1.EventRewardsSettled"},
+				{Type: "emissions.v1.EventNetworkLossSet"},
+				{Type: "emissions.v2.EventScoresSet"},
+			},
+		},
+		{
+			name: "Some events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.EventScoresSet"},
+						{Type: "emissions.v1.UnknownEvent"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v3.EventRewardsSettled"},
+							{Type: "emissions.v1.AnotherUnknownEvent"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v1.EventScoresSet"},
+				{Type: "emissions.v3.EventRewardsSettled"},
+			},
+		},
+		{
+			name: "No events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.UnknownEvent"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v1.AnotherUnknownEvent"},
+						}},
+					},
+				},
+			},
+			expected: []Event{},
+		},
+		{
+			name: "Two-digit version event",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v12.EventScoresSet"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v12.EventRewardsSettled"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v12.EventScoresSet"},
+				{Type: "emissions.v12.EventRewardsSettled"},
+			},
+		},
+		{
+			name: "Event with no version",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "EventScoresSet"}, // No version
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "EventRewardsSettled"}, // No version
+						}},
+					},
+				},
+			},
+			expected: []Event{}, // Should not match any
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterEvents(tt.events, whitelist)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d events, got %d", len(tt.expected), len(result))
+			}
+			for i, event := range result {
+				if event.Type != tt.expected[i].Type {
+					t.Errorf("expected event type %s, got %s", tt.expected[i].Type, event.Type)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBaseEventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		expected  string
+	}{
+		{
+			name:      "Valid event type with version",
+			eventType: "emissions.v1.EventScoresSet",
+			expected:  "EventScoresSet",
+		},
+		{
+			name:      "Valid event type with two-digit version",
+			eventType: "emissions.v12.EventRewardsSettled",
+			expected:  "EventRewardsSettled",
+		},
+		{
+			name:      "Valid event type without version",
+			eventType: "EventNetworkLossSet",
+			expected:  string(InvalidType),
+		},
+		{
+			name:      "Invalid event type",
+			eventType: "InvalidEventType",
+			expected:  string(InvalidType), // Expecting InvalidType
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getBaseEventType(tt.eventType)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/process_topic.go
+++ b/process_topic.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"strconv"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
 


### PR DESCRIPTION
* Control of max concurrency subroutines, configurable (new env var `MAX_CONCURRENT_TX_PROCESSING` )
* Use version-agnostic events
* Add v0.4.0 version tx  (v3)
* Docker updates to v3
* Ability to start at a particular block, with new env var `BOOTSTRAP_BLOCKHEIGHT`
* Better error handling (or error handling at all)
* Adding context passing in processTx (TODO apply in all others where applicable)
* SQL working from scratch too
* minor other stuff

* no duplicate key errors locally now, with 5 workers like in the indexer :shrug: 
----
* Added unit test

TODO: A lot, but this should fix the current state! 
Tested locally, works fine with 5 workers locally and 32 concurrent routines.