### PR TITLE
Update indexer to a v0.4.0 working state (#19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 data/
 postgres_data/
-allora-cosmos-pump
+allora-indexer
 pump
 allorad
 vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,13 @@ RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/ap
 
 # Detect the architecture and download the appropriate binary
 ARG TARGETARCH="amd64"
-RUN mkdir -p /usr/local/bin/previous/v3 && \
+RUN mkdir -p /usr/local/bin/previous/v2 && \
+    mkdir -p /usr/local/bin/previous/v3 && \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.2.14/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v2/allorad; \
     curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v3/allorad; \
     curl -L https://github.com/allora-network/allora-chain/releases/download/v0.4.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
     chmod -R 777 /usr/local/bin/allorad && \
+    chmod -R 777 /usr/local/bin/previous/v2/allorad && \
     chmod -R 777 /usr/local/bin/previous/v3/allorad
 
 COPY --from=gobuilder /src/allora-indexer /usr/local/bin/allora-indexer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,14 @@
 FROM golang:1.22-bookworm AS gobuilder
-ADD . /src
+
 WORKDIR /src
+
+# Copy go.mod and go.sum files first to leverage caching
+COPY go.mod go.sum ./
+
+# Download dependencies
+RUN go mod download
+
+COPY . .
 RUN go build .
 
 # final image
@@ -26,12 +34,12 @@ RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/ap
 
 # Detect the architecture and download the appropriate binary
 ARG TARGETARCH="amd64"
-RUN mkdir -p /usr/local/bin/previous/v2 && \
-    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.2.14/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v2/allorad; \
-    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
+RUN mkdir -p /usr/local/bin/previous/v3 && \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v3/allorad; \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.4.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
     chmod -R 777 /usr/local/bin/allorad && \
-    chmod -R 777 /usr/local/bin/previous/v2/allorad
+    chmod -R 777 /usr/local/bin/previous/v3/allorad
 
-COPY --from=gobuilder /src/allora-cosmos-pump /usr/local/bin/allora-cosmos-pump
+COPY --from=gobuilder /src/allora-indexer /usr/local/bin/allora-indexer
 # EXPOSE 8080
-ENTRYPOINT ["allora-cosmos-pump"]
+ENTRYPOINT ["allora-indexer"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
-BINARY_NAME := pump
+BINARY_NAME := allora-indexer
 # don't override user values
 ifeq (,$(VERSION))
   VERSION := $(shell git describe --exact-match 2>/dev/null)

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
-  provider:
+  indexer:
     build:
       context: .
       dockerfile: Dockerfile
@@ -25,6 +25,8 @@ services:
       - --S3_BUCKET_NAME=${S3_BUCKET_NAME}
       - --S3_FILE_KEY=${S3_FILE_KEY}
       - --MODE=${MODE}
+      - --BOOTSTRAP_BLOCKHEIGHT=${BOOTSTRAP_BLOCKHEIGHT}
+      - --MAX_CONCURRENT_TX_PROCESSING=${MAX_CONCURRENT_TX_PROCESSING}
 
 volumes:
   postgres_data:

--- a/db.go
+++ b/db.go
@@ -552,204 +552,295 @@ type EventRecord struct {
 	Data   json.RawMessage
 }
 
-func insertEvents(events []EventRecord) error {
-	log.Debug().Int("events", len(events)).Msg("inserting events")
-	for _, event := range events {
-		data, err := json.Marshal(event.Data)
-		if err != nil {
-			return err
-		}
-		var dataHash = hash(string(data))
-		_, err = dbPool.Exec(context.Background(), `
-			INSERT INTO `+TB_EVENTS+` (height, type, sender, data, hash) VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (height, hash, type) DO NOTHING`,
-			event.Height, event.Type, event.Sender, string(data), dataHash)
-		if err != nil {
-			return fmt.Errorf("event insert failed: %v", err)
-		}
+func isEventType(eventType, prefix, suffix string) bool {
+	return strings.HasPrefix(eventType, prefix) && strings.HasSuffix(eventType, suffix)
+}
 
-		// Additional handling for scores and rewards
-		switch {
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventScoresSet"):
-			err = insertScore(event)
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventRewardsSettled"):
-			err = insertReward(event)
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventNetworkLossSet"):
-			err = insertNetworkLoss(event)
-		default:
-			log.Info().Str("Event type", event.Type).Msg("skipping event type ")
-			continue
-		}
-		if err != nil {
-			return err
+// isScoreEvent checks if the event is a score event based on its type.
+func isScoreEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventScoresSet")
+}
+
+// isRewardEvent checks if the event is a reward event based on its type.
+func isRewardEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventRewardsSettled")
+}
+
+// isNetworkLossEvent checks if the event is a network loss event based on its type.
+func isNetworkLossEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventNetworkLossSet")
+}
+
+func insertEvents(events []EventRecord) error {
+	var scoreEvents []EventRecord
+	var rewardEvents []EventRecord
+	var networkLossEvents []EventRecord
+
+	for _, event := range events {
+		// Determine the type of event and accumulate accordingly
+		if isScoreEvent(event) { // Function to check if it's a score event
+			scoreEvents = append(scoreEvents, event)
+		} else if isRewardEvent(event) { // Function to check if it's a reward event
+			rewardEvents = append(rewardEvents, event)
+		} else if isNetworkLossEvent(event) { // Function to check if it's a network loss event
+			networkLossEvents = append(networkLossEvents, event)
 		}
 	}
+
+	// Insert scores if any
+	if len(scoreEvents) > 0 {
+		err := insertScore(scoreEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert scores: %w", err)
+		}
+	}
+
+	// Insert rewards if any
+	if len(rewardEvents) > 0 {
+		err := insertReward(rewardEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert rewards: %w", err)
+		}
+	}
+
+	// Insert network losses if any
+	if len(networkLossEvents) > 0 {
+		err := insertNetworkLoss(networkLossEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert network losses: %w", err)
+		}
+	}
+
 	return nil
 }
 
-func insertScore(event EventRecord) error {
-	log.Info().Interface("Event score", event).Msg("inserting event score ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+func insertScore(events []EventRecord) error {
+	log.Info().Msg("Inserting scores in batch")
+	var insertStatements []string
+	var values []interface{}
 
-	var topicID int
-	var actorType string
-	var addresses []string
-	var scores []big.Float
-	var block_height int
+	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
-	for _, attr := range attributes {
-		switch attr.Key {
-		case "topic_id":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
+	for _, event := range events {
+		log.Info().Interface("Event score", event).Msg("Processing event score")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal event data: %w", err)
+		}
+
+		var topicID int
+		var actorType string
+		var addresses []string
+		var scores []big.Float
+		var blockHeight int
+
+		for _, attr := range attributes {
+			switch attr.Key {
+			case "topic_id":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert topic_id to int: %w", err)
+				}
+			case "actor_type":
+				actorType = strings.Trim(attr.Value, "\"")
+			case "block_height":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				blockHeight, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert block_height to int: %w", err)
+				}
+			case "addresses":
+				err = json.Unmarshal([]byte(attr.Value), &addresses)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal addresses: %w", err)
+				}
+			case "scores":
+				var rawScores []string
+				err = json.Unmarshal([]byte(attr.Value), &rawScores)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal scores: %w", err)
+				}
+
+				for _, rawScore := range rawScores {
+					rawScoreClean := strings.Trim(rawScore, "\"")
+					if isInvalidNumericValue(rawScoreClean) {
+						log.Error().Str("rawScore", rawScore).Msg("Failed to convert score to big.Float")
+						return fmt.Errorf("Invalid Score: %s", rawScoreClean)
+					} else {
+						score := new(big.Float)
+						score, ok := score.SetString(rawScoreClean)
+						if !ok {
+							log.Error().Str("rawScore", rawScore).Msg("Failed to convert score to big.Float")
+							return fmt.Errorf("Invalid Score: %s", rawScoreClean)
+						}
+						scores = append(scores, *score)
+					}
+				}
 			}
-		case "actor_type":
-			actorType = strings.Trim(attr.Value, "\"")
-		case "block_height":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "addresses":
-			err = json.Unmarshal([]byte(attr.Value), &addresses)
-			if err != nil {
-				return err
-			}
-		case "scores":
-			err = json.Unmarshal([]byte(attr.Value), &scores)
-			if err != nil {
-				return err
-			}
+		}
+
+		if len(addresses) != len(scores) {
+			return fmt.Errorf("mismatch in length of addresses and scores")
+		}
+
+		for i := range addresses {
+			// Generate the placeholders for this row
+			newStmt := fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d)", placeholderCounter, placeholderCounter+1, placeholderCounter+2, placeholderCounter+3, placeholderCounter+4, placeholderCounter+5)
+			insertStatements = append(insertStatements, newStmt)
+			scoreValue := scores[i].Text('f', -1)
+			values = append(values, event.Height, blockHeight, topicID, actorType, addresses[i], scoreValue)
+			placeholderCounter += 6 // Increase counter for next row
 		}
 	}
 
-	if len(addresses) != len(scores) {
-		return fmt.Errorf("mismatch in length of addresses and scores")
-	}
+	if len(insertStatements) > 0 {
+		sqlStatement := fmt.Sprintf(`
+			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
+			VALUES %s`, TB_SCORES, strings.Join(insertStatements, ","))
 
-	for i := range addresses {
-		_, err = dbPool.Exec(context.Background(), `
-			INSERT INTO `+TB_SCORES+` (height_tx, height, topic_id, type, address, value) VALUES ($1, $2, $3, $4, $5, $6) 
-			ON CONFLICT (height, topic_id, type, address) DO NOTHING`,
-			event.Height, block_height, topicID, actorType, addresses[i], scores[i].Text('f', -1))
+		log.Info().Str("Event - Score SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
+
+		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
 		if err != nil {
 			return fmt.Errorf("score insert failed: %v", err)
 		}
+	} else {
+		log.Info().Msg("No scores data to insert")
 	}
+
 	return nil
 }
 
-func insertReward(event EventRecord) error {
-	log.Info().Interface("Event reward", event).Msg("inserting event reward ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+func insertReward(events []EventRecord) error {
+	log.Info().Msg("Inserting rewards in batch")
+	var insertStatements []string
+	var values []interface{}
+	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
-	var topicID int
-	var rewardType string
-	var addresses []string
-	var rewards []big.Float
-	var block_height int
-
-	for _, attr := range attributes {
-		switch attr.Key {
-		case "topic_id":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "reward_type":
-			rewardType = strings.Trim(attr.Value, "\"")
-		case "block_height":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "addresses":
-			err = json.Unmarshal([]byte(attr.Value), &addresses)
-			if err != nil {
-				return err
-			}
-		case "rewards":
-			err = json.Unmarshal([]byte(attr.Value), &rewards)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if len(addresses) != len(rewards) {
-		return fmt.Errorf("mismatch in length of addresses and rewards")
-	}
-
-	for i := range addresses {
-		_, err = dbPool.Exec(context.Background(),
-			`INSERT INTO `+TB_REWARDS+` (height_tx, height, topic_id, type, address, value) VALUES ($1, $2, $3, $4, $5, $6) 
-			ON CONFLICT (height, topic_id, type, address) DO NOTHING`,
-			event.Height, block_height, topicID, rewardType, addresses[i], rewards[i].Text('f', -1))
+	for _, event := range events {
+		log.Info().Interface("Event reward", event).Msg("Processing event reward")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
 		if err != nil {
-			return fmt.Errorf("reward insert failed: %v", err)
+			return fmt.Errorf("failed to unmarshal event data: %w", err)
+		}
+
+		var topicID int
+		var rewardType string
+		var addresses []string
+		var rewards []big.Float
+		var blockHeight int
+
+		for _, attr := range attributes {
+			switch attr.Key {
+			case "topic_id":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert topic_id to int: %w", err)
+				}
+			case "reward_type":
+				rewardType = strings.Trim(attr.Value, "\"")
+			case "block_height":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				blockHeight, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert block_height to int: %w", err)
+				}
+			case "addresses":
+				err = json.Unmarshal([]byte(attr.Value), &addresses)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal addresses: %w", err)
+				}
+			case "rewards":
+				err = json.Unmarshal([]byte(attr.Value), &rewards)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal rewards: %w", err)
+				}
+			}
+		}
+
+		if len(addresses) != len(rewards) {
+			return fmt.Errorf("mismatch in length of addresses and rewards")
+		}
+
+		for i := range addresses {
+			// Generate the placeholders for this row
+			newStmt := fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d)", placeholderCounter, placeholderCounter+1, placeholderCounter+2, placeholderCounter+3, placeholderCounter+4, placeholderCounter+5)
+			insertStatements = append(insertStatements, newStmt)
+			values = append(values, event.Height, blockHeight, topicID, rewardType, addresses[i], rewards[i].Text('f', -1))
+			placeholderCounter += 6 // Increase counter for next row
 		}
 	}
+
+	if len(insertStatements) > 0 {
+		sqlStatement := fmt.Sprintf(`
+			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
+			VALUES %s`, TB_REWARDS, strings.Join(insertStatements, ","))
+
+		log.Info().Str("Event - Reward SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
+
+		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
+		if err != nil {
+			return fmt.Errorf("rewards insert failed: %v", err)
+		}
+	} else {
+		log.Info().Msg("No rewards data to insert")
+	}
+
 	return nil
 }
 
-func insertNetworkLoss(event EventRecord) error {
-	log.Info().Interface("Event network loss", event).Msg("inserting event network loss ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+// func insertNetworkLoss(event EventRecord) error {
+func insertNetworkLoss(events []EventRecord) error {
+	for _, event := range events {
+		log.Info().Interface("Event network loss", event).Msg("inserting event network loss ")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
+		if err != nil {
+			return err
+		}
 
-	var topicID int
-	var block_height int
-	var valueBundle types.MsgValueBundle
+		var topicID int
+		var block_height int
+		var valueBundle types.MsgValueBundle
 
-	for _, attr := range attributes {
-		cleanedValue := strings.Trim(attr.Value, "\"")
-		switch attr.Key {
-		case "topic_id":
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "block_height":
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "value_bundle":
-			err = json.Unmarshal([]byte(cleanedValue), &valueBundle)
-			if err != nil {
-				return err
+		for _, attr := range attributes {
+			cleanedValue := strings.Trim(attr.Value, "\"")
+			switch attr.Key {
+			case "topic_id":
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return err
+				}
+			case "block_height":
+				block_height, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return err
+				}
+			case "value_bundle":
+				err = json.Unmarshal([]byte(cleanedValue), &valueBundle)
+				if err != nil {
+					return err
+				}
 			}
 		}
+
+		var bundleId uint64
+		err = dbPool.QueryRow(context.Background(), `
+				INSERT INTO `+TB_NETWORKLOSSES+` (height_tx, height, topic_id, naive_value, combined_value) VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (height_tx, height, topic_id) DO NOTHING returning id`,
+			event.Height, block_height, topicID, valueBundle.NaiveValue, valueBundle.CombinedValue).Scan(&bundleId)
+
+		if err != nil {
+			return fmt.Errorf("network loss event insert failed: %v", err)
+		}
+
+		log.Info().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
+		insertValueBundle(bundleId, valueBundle, TB_NETWORKLOSS_BUNDLE_VALUES)
 	}
-
-	var bundleId uint64
-	err = dbPool.QueryRow(context.Background(), `
-			INSERT INTO `+TB_NETWORKLOSSES+` (height_tx, height, topic_id, naive_value, combined_value) VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (height_tx, height, topic_id) DO NOTHING returning id`,
-		event.Height, block_height, topicID, valueBundle.NaiveValue, valueBundle.CombinedValue).Scan(&bundleId)
-
-	if err != nil {
-		return fmt.Errorf("network loss event insert failed: %v", err)
-	}
-
-	log.Info().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
-	insertValueBundle(bundleId, valueBundle, TB_NETWORKLOSS_BUNDLE_VALUES)
 	return nil
 }
 
@@ -800,7 +891,7 @@ func insertValueBundle(
 		}
 	}
 	//Insert ForecasterValues
-	for _, val := range valueBundle.InfererValues {
+	for _, val := range valueBundle.ForecasterValues {
 		_, err := dbPool.Exec(context.Background(), `
 				INSERT INTO `+tableName+` (
 					bundle_id,
@@ -929,4 +1020,8 @@ func hash(s string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return h.Sum32()
+}
+
+func isInvalidNumericValue(value string) bool {
+	return strings.Contains(strings.ToLower(value), "infinity") || strings.Contains(strings.ToLower(value), "nan")
 }

--- a/db.go
+++ b/db.go
@@ -622,7 +622,7 @@ func insertScore(events []EventRecord) error {
 	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
 	for _, event := range events {
-		log.Info().Interface("Event score", event).Msg("Processing event score")
+		log.Trace().Interface("Event score", event).Msg("Processing event score")
 		var attributes []Attribute
 		err := json.Unmarshal(event.Data, &attributes)
 		if err != nil {
@@ -699,9 +699,7 @@ func insertScore(events []EventRecord) error {
 		sqlStatement := fmt.Sprintf(`
 			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
 			VALUES %s`, TB_SCORES, strings.Join(insertStatements, ","))
-
-		log.Info().Str("Event - Score SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
-
+		log.Trace().Str("Event - Score SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
 		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
 		if err != nil {
 			return fmt.Errorf("score insert failed: %v", err)
@@ -720,7 +718,7 @@ func insertReward(events []EventRecord) error {
 	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
 	for _, event := range events {
-		log.Info().Interface("Event reward", event).Msg("Processing event reward")
+		log.Trace().Interface("Event reward", event).Msg("Processing event reward")
 		var attributes []Attribute
 		err := json.Unmarshal(event.Data, &attributes)
 		if err != nil {
@@ -741,7 +739,7 @@ func insertReward(events []EventRecord) error {
 				if err != nil {
 					return fmt.Errorf("failed to convert topic_id to int: %w", err)
 				}
-			case "reward_type":
+			case "actor_type":
 				rewardType = strings.Trim(attr.Value, "\"")
 			case "block_height":
 				cleanedValue := strings.Trim(attr.Value, "\"")
@@ -780,7 +778,7 @@ func insertReward(events []EventRecord) error {
 			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
 			VALUES %s`, TB_REWARDS, strings.Join(insertStatements, ","))
 
-		log.Info().Str("Event - Reward SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
+		log.Trace().Str("Event - Reward SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
 
 		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
 		if err != nil {
@@ -796,7 +794,7 @@ func insertReward(events []EventRecord) error {
 // func insertNetworkLoss(event EventRecord) error {
 func insertNetworkLoss(events []EventRecord) error {
 	for _, event := range events {
-		log.Info().Interface("Event network loss", event).Msg("inserting event network loss ")
+		log.Debug().Interface("Event network loss", event).Msg("inserting event network loss ")
 		var attributes []Attribute
 		err := json.Unmarshal(event.Data, &attributes)
 		if err != nil {
@@ -838,7 +836,7 @@ func insertNetworkLoss(events []EventRecord) error {
 			return fmt.Errorf("network loss event insert failed: %v", err)
 		}
 
-		log.Info().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
+		log.Debug().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
 		insertValueBundle(bundleId, valueBundle, TB_NETWORKLOSS_BUNDLE_VALUES)
 	}
 	return nil

--- a/execute.go
+++ b/execute.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/allora-network/allora-cosmos-pump/types"
-	"github.com/rs/zerolog/log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	"github.com/allora-network/allora-indexer/types"
+	"github.com/rs/zerolog/log"
 )
 
 func ExecuteCommand(cliApp, node string, parts []string) ([]byte, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/allora-network/allora-cosmos-pump
+module github.com/allora-network/allora-indexer
 
 go 1.22
 

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Define the application name
-APP_NAME="allora-cosmos-pump"
+APP_NAME="allora-indexer"
 
 # Check for a version argument, otherwise set a default version
 VERSION=${1:-"v0.0.1"}
 
 # Define the base URL using the specified or default version
-BASE_URL="https://github.com/allora-network/allora-cosmos-pump/releases/download/$VERSION"
+BASE_URL="https://github.com/allora-network/allora-indexer/releases/download/$VERSION"
 
 # Determine the operating system and architecture
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func run() error {
 		Bool("EXIT_APP", exitWhenCaughtUp).
 		Int64("BOOTSTRAP_BLOCKHEIGHT", bootstrapBlockHeight).
 		Uint("MAX_CONCURRENT_TX_PROCESSING", maxConcurrentTxPerRoutine).
-		Msg("pump started")
+		Msg("Allora Indexer started")
 
 	// define the commands to execute payloads
 	config = ClientConfig{

--- a/process_block.go
+++ b/process_block.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
-
 
 func getLatestHeight() (uint64, error) {
 	blockInfo, err := ExecuteCommandByKey[types.BlockInfo](config, "latestBlock")
@@ -27,7 +26,7 @@ func getLatestHeight() (uint64, error) {
 	return uint64(latestHeight), nil
 }
 
-func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error){
+func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error) {
 	// Convert height to string
 	heightStr := strconv.FormatUint(height, 10)
 
@@ -59,7 +58,7 @@ func fetchBlock(config ClientConfig, height uint64) (types.BlockQuery, error){
 	// processBlockQuery(config, blockQuery)
 }
 
-func writeBlock(config ClientConfig, blockQuery types.BlockQuery) (error) {
+func writeBlock(config ClientConfig, blockQuery types.BlockQuery) error {
 	// Process the block information (e.g., insert into database)
 	// Assuming `insertBlockInfo` is defined elsewhere
 	height, err := strconv.ParseUint(blockQuery.Header.Height, 10, 64)

--- a/process_consensus.go
+++ b/process_consensus.go
@@ -3,7 +3,7 @@ package main
 import (
 	"strings"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
 

--- a/process_events_test.go
+++ b/process_events_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestFilterEvents(t *testing.T) {
+	whitelist := map[string]EventProcessing{
+		"EventScoresSet":      {Type: ScoreEvent},
+		"EventRewardsSettled": {Type: RewardEvent},
+		"EventNetworkLossSet": {Type: NetworkLossEvent},
+	}
+
+	tests := []struct {
+		name     string
+		events   *BlockResult
+		expected []Event
+	}{
+		{
+			name: "All events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.EventScoresSet"},
+						{Type: "emissions.v1.EventRewardsSettled"},
+						{Type: "emissions.v1.EventNetworkLossSet"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v2.EventScoresSet"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v1.EventScoresSet"},
+				{Type: "emissions.v1.EventRewardsSettled"},
+				{Type: "emissions.v1.EventNetworkLossSet"},
+				{Type: "emissions.v2.EventScoresSet"},
+			},
+		},
+		{
+			name: "Some events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.EventScoresSet"},
+						{Type: "emissions.v1.UnknownEvent"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v3.EventRewardsSettled"},
+							{Type: "emissions.v1.AnotherUnknownEvent"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v1.EventScoresSet"},
+				{Type: "emissions.v3.EventRewardsSettled"},
+			},
+		},
+		{
+			name: "No events match",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v1.UnknownEvent"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v1.AnotherUnknownEvent"},
+						}},
+					},
+				},
+			},
+			expected: []Event{},
+		},
+		{
+			name: "Two-digit version event",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "emissions.v12.EventScoresSet"},
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "emissions.v12.EventRewardsSettled"},
+						}},
+					},
+				},
+			},
+			expected: []Event{
+				{Type: "emissions.v12.EventScoresSet"},
+				{Type: "emissions.v12.EventRewardsSettled"},
+			},
+		},
+		{
+			name: "Event with no version",
+			events: &BlockResult{
+				Result: struct {
+					Height              string    `json:"height"`
+					FinalizeBlockEvents []Event   `json:"finalize_block_events"`
+					TxsBlockEvents      []TxEvent `json:"txs_results"`
+				}{
+					FinalizeBlockEvents: []Event{
+						{Type: "EventScoresSet"}, // No version
+					},
+					TxsBlockEvents: []TxEvent{
+						{Events: []Event{
+							{Type: "EventRewardsSettled"}, // No version
+						}},
+					},
+				},
+			},
+			expected: []Event{}, // Should not match any
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FilterEvents(tt.events, whitelist)
+			if len(result) != len(tt.expected) {
+				t.Errorf("expected %d events, got %d", len(tt.expected), len(result))
+			}
+			for i, event := range result {
+				if event.Type != tt.expected[i].Type {
+					t.Errorf("expected event type %s, got %s", tt.expected[i].Type, event.Type)
+				}
+			}
+		})
+	}
+}
+
+func TestGetBaseEventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		expected  string
+	}{
+		{
+			name:      "Valid event type with version",
+			eventType: "emissions.v1.EventScoresSet",
+			expected:  "EventScoresSet",
+		},
+		{
+			name:      "Valid event type with two-digit version",
+			eventType: "emissions.v12.EventRewardsSettled",
+			expected:  "EventRewardsSettled",
+		},
+		{
+			name:      "Valid event type without version",
+			eventType: "EventNetworkLossSet",
+			expected:  string(InvalidType),
+		},
+		{
+			name:      "Invalid event type",
+			eventType: "InvalidEventType",
+			expected:  string(InvalidType), // Expecting InvalidType
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getBaseEventType(tt.eventType)
+			if result != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/process_topic.go
+++ b/process_topic.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"strconv"
 
-	"github.com/allora-network/allora-cosmos-pump/types"
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/rs/zerolog/log"
 )
 


### PR DESCRIPTION
* Control of max concurrency subroutines, configurable (new env var `MAX_CONCURRENT_TX_PROCESSING` )
* Use version-agnostic events
* Add v0.4.0 version tx  (v3)
* Docker updates to v3
* Ability to start at a particular block, with new env var `BOOTSTRAP_BLOCKHEIGHT`
* Better error handling (or error handling at all)
* Adding context passing in processTx (TODO apply in all others where applicable)
* SQL working from scratch too
* remove allora-cosmos-pump references
* minor other stuff

* no duplicate key errors locally now, with 5 workers like in the indexer :shrug:
----
* Added unit test

TODO: A lot, but this should fix the current state!  Tested locally, works fine with 5 workers locally and 32 concurrent routines.