### PR TITLE
Fix previous version binary + batch reputer reqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,13 @@ RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/ap
 
 # Detect the architecture and download the appropriate binary
 ARG TARGETARCH="amd64"
-RUN mkdir -p /usr/local/bin/previous/v3 && \
+RUN mkdir -p /usr/local/bin/previous/v2 && \
+    mkdir -p /usr/local/bin/previous/v3 && \
+    curl -L https://github.com/allora-network/allora-chain/releases/download/v0.2.14/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v2/allorad; \
     curl -L https://github.com/allora-network/allora-chain/releases/download/v0.3.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/previous/v3/allorad; \
     curl -L https://github.com/allora-network/allora-chain/releases/download/v0.4.0/allorad_linux_${TARGETARCH} -o /usr/local/bin/allorad; \
     chmod -R 777 /usr/local/bin/allorad && \
+    chmod -R 777 /usr/local/bin/previous/v2/allorad && \
     chmod -R 777 /usr/local/bin/previous/v3/allorad
 
 COPY --from=gobuilder /src/allora-indexer /usr/local/bin/allora-indexer

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
-BINARY_NAME := pump
+BINARY_NAME := allora-indexer
 # don't override user values
 ifeq (,$(VERSION))
   VERSION := $(shell git describe --exact-match 2>/dev/null)

--- a/db.go
+++ b/db.go
@@ -552,204 +552,295 @@ type EventRecord struct {
 	Data   json.RawMessage
 }
 
-func insertEvents(events []EventRecord) error {
-	log.Debug().Int("events", len(events)).Msg("inserting events")
-	for _, event := range events {
-		data, err := json.Marshal(event.Data)
-		if err != nil {
-			return err
-		}
-		var dataHash = hash(string(data))
-		_, err = dbPool.Exec(context.Background(), `
-			INSERT INTO `+TB_EVENTS+` (height, type, sender, data, hash) VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (height, hash, type) DO NOTHING`,
-			event.Height, event.Type, event.Sender, string(data), dataHash)
-		if err != nil {
-			return fmt.Errorf("event insert failed: %v", err)
-		}
+func isEventType(eventType, prefix, suffix string) bool {
+	return strings.HasPrefix(eventType, prefix) && strings.HasSuffix(eventType, suffix)
+}
 
-		// Additional handling for scores and rewards
-		switch {
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventScoresSet"):
-			err = insertScore(event)
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventRewardsSettled"):
-			err = insertReward(event)
-		case strings.HasPrefix(event.Type, "emissions.v") && strings.HasSuffix(event.Type, "EventNetworkLossSet"):
-			err = insertNetworkLoss(event)
-		default:
-			log.Info().Str("Event type", event.Type).Msg("skipping event type ")
-			continue
-		}
-		if err != nil {
-			return err
+// isScoreEvent checks if the event is a score event based on its type.
+func isScoreEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventScoresSet")
+}
+
+// isRewardEvent checks if the event is a reward event based on its type.
+func isRewardEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventRewardsSettled")
+}
+
+// isNetworkLossEvent checks if the event is a network loss event based on its type.
+func isNetworkLossEvent(event EventRecord) bool {
+	return isEventType(event.Type, "emissions.v", "EventNetworkLossSet")
+}
+
+func insertEvents(events []EventRecord) error {
+	var scoreEvents []EventRecord
+	var rewardEvents []EventRecord
+	var networkLossEvents []EventRecord
+
+	for _, event := range events {
+		// Determine the type of event and accumulate accordingly
+		if isScoreEvent(event) { // Function to check if it's a score event
+			scoreEvents = append(scoreEvents, event)
+		} else if isRewardEvent(event) { // Function to check if it's a reward event
+			rewardEvents = append(rewardEvents, event)
+		} else if isNetworkLossEvent(event) { // Function to check if it's a network loss event
+			networkLossEvents = append(networkLossEvents, event)
 		}
 	}
+
+	// Insert scores if any
+	if len(scoreEvents) > 0 {
+		err := insertScore(scoreEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert scores: %w", err)
+		}
+	}
+
+	// Insert rewards if any
+	if len(rewardEvents) > 0 {
+		err := insertReward(rewardEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert rewards: %w", err)
+		}
+	}
+
+	// Insert network losses if any
+	if len(networkLossEvents) > 0 {
+		err := insertNetworkLoss(networkLossEvents)
+		if err != nil {
+			return fmt.Errorf("failed to insert network losses: %w", err)
+		}
+	}
+
 	return nil
 }
 
-func insertScore(event EventRecord) error {
-	log.Info().Interface("Event score", event).Msg("inserting event score ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+func insertScore(events []EventRecord) error {
+	log.Info().Msg("Inserting scores in batch")
+	var insertStatements []string
+	var values []interface{}
 
-	var topicID int
-	var actorType string
-	var addresses []string
-	var scores []big.Float
-	var block_height int
+	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
-	for _, attr := range attributes {
-		switch attr.Key {
-		case "topic_id":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
+	for _, event := range events {
+		log.Info().Interface("Event score", event).Msg("Processing event score")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
+		if err != nil {
+			return fmt.Errorf("failed to unmarshal event data: %w", err)
+		}
+
+		var topicID int
+		var actorType string
+		var addresses []string
+		var scores []big.Float
+		var blockHeight int
+
+		for _, attr := range attributes {
+			switch attr.Key {
+			case "topic_id":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert topic_id to int: %w", err)
+				}
+			case "actor_type":
+				actorType = strings.Trim(attr.Value, "\"")
+			case "block_height":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				blockHeight, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert block_height to int: %w", err)
+				}
+			case "addresses":
+				err = json.Unmarshal([]byte(attr.Value), &addresses)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal addresses: %w", err)
+				}
+			case "scores":
+				var rawScores []string
+				err = json.Unmarshal([]byte(attr.Value), &rawScores)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal scores: %w", err)
+				}
+
+				for _, rawScore := range rawScores {
+					rawScoreClean := strings.Trim(rawScore, "\"")
+					if isInvalidNumericValue(rawScoreClean) {
+						log.Error().Str("rawScore", rawScore).Msg("Failed to convert score to big.Float")
+						return fmt.Errorf("Invalid Score: %s", rawScoreClean)
+					} else {
+						score := new(big.Float)
+						score, ok := score.SetString(rawScoreClean)
+						if !ok {
+							log.Error().Str("rawScore", rawScore).Msg("Failed to convert score to big.Float")
+							return fmt.Errorf("Invalid Score: %s", rawScoreClean)
+						}
+						scores = append(scores, *score)
+					}
+				}
 			}
-		case "actor_type":
-			actorType = strings.Trim(attr.Value, "\"")
-		case "block_height":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "addresses":
-			err = json.Unmarshal([]byte(attr.Value), &addresses)
-			if err != nil {
-				return err
-			}
-		case "scores":
-			err = json.Unmarshal([]byte(attr.Value), &scores)
-			if err != nil {
-				return err
-			}
+		}
+
+		if len(addresses) != len(scores) {
+			return fmt.Errorf("mismatch in length of addresses and scores")
+		}
+
+		for i := range addresses {
+			// Generate the placeholders for this row
+			newStmt := fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d)", placeholderCounter, placeholderCounter+1, placeholderCounter+2, placeholderCounter+3, placeholderCounter+4, placeholderCounter+5)
+			insertStatements = append(insertStatements, newStmt)
+			scoreValue := scores[i].Text('f', -1)
+			values = append(values, event.Height, blockHeight, topicID, actorType, addresses[i], scoreValue)
+			placeholderCounter += 6 // Increase counter for next row
 		}
 	}
 
-	if len(addresses) != len(scores) {
-		return fmt.Errorf("mismatch in length of addresses and scores")
-	}
+	if len(insertStatements) > 0 {
+		sqlStatement := fmt.Sprintf(`
+			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
+			VALUES %s`, TB_SCORES, strings.Join(insertStatements, ","))
 
-	for i := range addresses {
-		_, err = dbPool.Exec(context.Background(), `
-			INSERT INTO `+TB_SCORES+` (height_tx, height, topic_id, type, address, value) VALUES ($1, $2, $3, $4, $5, $6) 
-			ON CONFLICT (height, topic_id, type, address) DO NOTHING`,
-			event.Height, block_height, topicID, actorType, addresses[i], scores[i].Text('f', -1))
+		log.Info().Str("Event - Score SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
+
+		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
 		if err != nil {
 			return fmt.Errorf("score insert failed: %v", err)
 		}
+	} else {
+		log.Info().Msg("No scores data to insert")
 	}
+
 	return nil
 }
 
-func insertReward(event EventRecord) error {
-	log.Info().Interface("Event reward", event).Msg("inserting event reward ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+func insertReward(events []EventRecord) error {
+	log.Info().Msg("Inserting rewards in batch")
+	var insertStatements []string
+	var values []interface{}
+	placeholderCounter := 1 // Placeholder index starts at 1 in PostgreSQL
 
-	var topicID int
-	var rewardType string
-	var addresses []string
-	var rewards []big.Float
-	var block_height int
-
-	for _, attr := range attributes {
-		switch attr.Key {
-		case "topic_id":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "reward_type":
-			rewardType = strings.Trim(attr.Value, "\"")
-		case "block_height":
-			cleanedValue := strings.Trim(attr.Value, "\"")
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "addresses":
-			err = json.Unmarshal([]byte(attr.Value), &addresses)
-			if err != nil {
-				return err
-			}
-		case "rewards":
-			err = json.Unmarshal([]byte(attr.Value), &rewards)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	if len(addresses) != len(rewards) {
-		return fmt.Errorf("mismatch in length of addresses and rewards")
-	}
-
-	for i := range addresses {
-		_, err = dbPool.Exec(context.Background(),
-			`INSERT INTO `+TB_REWARDS+` (height_tx, height, topic_id, type, address, value) VALUES ($1, $2, $3, $4, $5, $6) 
-			ON CONFLICT (height, topic_id, type, address) DO NOTHING`,
-			event.Height, block_height, topicID, rewardType, addresses[i], rewards[i].Text('f', -1))
+	for _, event := range events {
+		log.Info().Interface("Event reward", event).Msg("Processing event reward")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
 		if err != nil {
-			return fmt.Errorf("reward insert failed: %v", err)
+			return fmt.Errorf("failed to unmarshal event data: %w", err)
+		}
+
+		var topicID int
+		var rewardType string
+		var addresses []string
+		var rewards []big.Float
+		var blockHeight int
+
+		for _, attr := range attributes {
+			switch attr.Key {
+			case "topic_id":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert topic_id to int: %w", err)
+				}
+			case "reward_type":
+				rewardType = strings.Trim(attr.Value, "\"")
+			case "block_height":
+				cleanedValue := strings.Trim(attr.Value, "\"")
+				blockHeight, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return fmt.Errorf("failed to convert block_height to int: %w", err)
+				}
+			case "addresses":
+				err = json.Unmarshal([]byte(attr.Value), &addresses)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal addresses: %w", err)
+				}
+			case "rewards":
+				err = json.Unmarshal([]byte(attr.Value), &rewards)
+				if err != nil {
+					return fmt.Errorf("failed to unmarshal rewards: %w", err)
+				}
+			}
+		}
+
+		if len(addresses) != len(rewards) {
+			return fmt.Errorf("mismatch in length of addresses and rewards")
+		}
+
+		for i := range addresses {
+			// Generate the placeholders for this row
+			newStmt := fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d)", placeholderCounter, placeholderCounter+1, placeholderCounter+2, placeholderCounter+3, placeholderCounter+4, placeholderCounter+5)
+			insertStatements = append(insertStatements, newStmt)
+			values = append(values, event.Height, blockHeight, topicID, rewardType, addresses[i], rewards[i].Text('f', -1))
+			placeholderCounter += 6 // Increase counter for next row
 		}
 	}
+
+	if len(insertStatements) > 0 {
+		sqlStatement := fmt.Sprintf(`
+			INSERT INTO %s (height_tx, height, topic_id, type, address, value) 
+			VALUES %s`, TB_REWARDS, strings.Join(insertStatements, ","))
+
+		log.Info().Str("Event - Reward SQL Statement", sqlStatement).Interface("Values", values).Msg("Executing batch insert for scores")
+
+		_, err := dbPool.Exec(context.Background(), sqlStatement, values...)
+		if err != nil {
+			return fmt.Errorf("rewards insert failed: %v", err)
+		}
+	} else {
+		log.Info().Msg("No rewards data to insert")
+	}
+
 	return nil
 }
 
-func insertNetworkLoss(event EventRecord) error {
-	log.Info().Interface("Event network loss", event).Msg("inserting event network loss ")
-	var attributes []Attribute
-	err := json.Unmarshal(event.Data, &attributes)
-	if err != nil {
-		return err
-	}
+// func insertNetworkLoss(event EventRecord) error {
+func insertNetworkLoss(events []EventRecord) error {
+	for _, event := range events {
+		log.Info().Interface("Event network loss", event).Msg("inserting event network loss ")
+		var attributes []Attribute
+		err := json.Unmarshal(event.Data, &attributes)
+		if err != nil {
+			return err
+		}
 
-	var topicID int
-	var block_height int
-	var valueBundle types.MsgValueBundle
+		var topicID int
+		var block_height int
+		var valueBundle types.MsgValueBundle
 
-	for _, attr := range attributes {
-		cleanedValue := strings.Trim(attr.Value, "\"")
-		switch attr.Key {
-		case "topic_id":
-			topicID, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "block_height":
-			block_height, err = strconv.Atoi(cleanedValue)
-			if err != nil {
-				return err
-			}
-		case "value_bundle":
-			err = json.Unmarshal([]byte(cleanedValue), &valueBundle)
-			if err != nil {
-				return err
+		for _, attr := range attributes {
+			cleanedValue := strings.Trim(attr.Value, "\"")
+			switch attr.Key {
+			case "topic_id":
+				topicID, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return err
+				}
+			case "block_height":
+				block_height, err = strconv.Atoi(cleanedValue)
+				if err != nil {
+					return err
+				}
+			case "value_bundle":
+				err = json.Unmarshal([]byte(cleanedValue), &valueBundle)
+				if err != nil {
+					return err
+				}
 			}
 		}
+
+		var bundleId uint64
+		err = dbPool.QueryRow(context.Background(), `
+				INSERT INTO `+TB_NETWORKLOSSES+` (height_tx, height, topic_id, naive_value, combined_value) VALUES ($1, $2, $3, $4, $5)
+				ON CONFLICT (height_tx, height, topic_id) DO NOTHING returning id`,
+			event.Height, block_height, topicID, valueBundle.NaiveValue, valueBundle.CombinedValue).Scan(&bundleId)
+
+		if err != nil {
+			return fmt.Errorf("network loss event insert failed: %v", err)
+		}
+
+		log.Info().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
+		insertValueBundle(bundleId, valueBundle, TB_NETWORKLOSS_BUNDLE_VALUES)
 	}
-
-	var bundleId uint64
-	err = dbPool.QueryRow(context.Background(), `
-			INSERT INTO `+TB_NETWORKLOSSES+` (height_tx, height, topic_id, naive_value, combined_value) VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (height_tx, height, topic_id) DO NOTHING returning id`,
-		event.Height, block_height, topicID, valueBundle.NaiveValue, valueBundle.CombinedValue).Scan(&bundleId)
-
-	if err != nil {
-		return fmt.Errorf("network loss event insert failed: %v", err)
-	}
-
-	log.Info().Msgf("Inserting NetworkLoss bundle: %d, %v", bundleId, valueBundle)
-	insertValueBundle(bundleId, valueBundle, TB_NETWORKLOSS_BUNDLE_VALUES)
 	return nil
 }
 
@@ -929,4 +1020,8 @@ func hash(s string) uint32 {
 	h := fnv.New32a()
 	h.Write([]byte(s))
 	return h.Sum32()
+}
+
+func isInvalidNumericValue(value string) bool {
+	return strings.Contains(strings.ToLower(value), "infinity") || strings.Contains(strings.ToLower(value), "nan")
 }

--- a/db.go
+++ b/db.go
@@ -800,7 +800,7 @@ func insertValueBundle(
 		}
 	}
 	//Insert ForecasterValues
-	for _, val := range valueBundle.InfererValues {
+	for _, val := range valueBundle.ForecasterValues {
 		_, err := dbPool.Exec(context.Background(), `
 				INSERT INTO `+tableName+` (
 					bundle_id,

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func run() error {
 		Bool("EXIT_APP", exitWhenCaughtUp).
 		Int64("BOOTSTRAP_BLOCKHEIGHT", bootstrapBlockHeight).
 		Uint("MAX_CONCURRENT_TX_PROCESSING", maxConcurrentTxPerRoutine).
-		Msg("pump started")
+		Msg("Allora Indexer started")
 
 	// define the commands to execute payloads
 	config = ClientConfig{

--- a/process_tx.go
+++ b/process_tx.go
@@ -30,7 +30,7 @@ func processTx(ctx context.Context, wg *sync.WaitGroup, height uint64, txData st
 
 	// Decode the transaction using the decodeTx function
 	//txMessage, err := ExecuteCommandByKey[types.Tx](config, "decodeTx", txData)
-	txMessage, err := DecodeTx(config, txData)
+	txMessage, err := DecodeTx(config, txData, height)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to execute command")
 		return err

--- a/process_tx.go
+++ b/process_tx.go
@@ -178,7 +178,7 @@ func insertBulkReputerPayload(blockHeight uint64, messageId uint64, msg types.Ms
 		reputer_nonce_block_height, msg.TopicID,
 	).Scan(&payloadId)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert reputer_payload")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer_payload")
 		return err
 	}
 
@@ -189,7 +189,7 @@ func insertBulkReputerPayload(blockHeight uint64, messageId uint64, msg types.Ms
 		request_reputer_nonce_block_height, err := strconv.Atoi(bundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight)
 		err = insertAddress("allora", sql.NullString{"", false}, sql.NullString{bundle.Pubkey, true}, "")
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to insert bundle.Pubkey insertAddress")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert bundle.Pubkey insertAddress")
 			return err
 		}
 		err = dbPool.QueryRow(context.Background(), `
@@ -211,11 +211,12 @@ func insertBulkReputerPayload(blockHeight uint64, messageId uint64, msg types.Ms
 			request_reputer_nonce_block_height,
 		).Scan(&bundleId)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to insert reputer_bundles")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer_bundles")
 			return err
 		}
 		err = insertValueBundle(bundleId, bundle.ValueBundle, TB_BUNDLE_VALUES)
 		if err != nil {
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer bundle_values")
 			return err
 		}
 	}
@@ -224,55 +225,52 @@ func insertBulkReputerPayload(blockHeight uint64, messageId uint64, msg types.Ms
 }
 
 func insertReputerPayload(blockHeight uint64, messageId uint64, msg types.MsgInsertReputerPayload) error {
-
-	reputer_nonce_block_height, err := strconv.Atoi(msg.ReputerValueBundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight)
-	var payloadId uint64
-	err = dbPool.QueryRow(context.Background(), `
-		INSERT INTO `+TB_REPUTER_PAYLOAD+` (
-			message_height,
-			message_id,
-			sender,
-			reputer_nonce_block_height,
-			topic_id
-		) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
-		blockHeight, messageId, msg.Sender,
-		reputer_nonce_block_height, msg.ReputerValueBundle.ValueBundle.TopicID,
-	).Scan(&payloadId)
+	nonce_block_height, err := strconv.Atoi(msg.ReputerValueBundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert reputer_payload")
+		log.Error().Err(err).Msg("Failed to convert inf.Nonce.BlockHeight to int")
+		return err
+	}
+	topic_id, err := strconv.Atoi(msg.ReputerValueBundle.ValueBundle.TopicID)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to convert inf.TopicID to int")
 		return err
 	}
 
-	var bundleId uint64
-	log.Info().Msgf("Inserting bundle: %v", msg.ReputerValueBundle)
+	// Insert address for the pubkey
 	err = insertAddress("allora", sql.NullString{"", false}, sql.NullString{msg.ReputerValueBundle.Pubkey, true}, "")
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to insert bundle.Pubkey insertAddress")
 		return err
 	}
-	err = dbPool.QueryRow(context.Background(), `
-			INSERT INTO `+TB_REPUTER_BUNDLES+` (
-				reputer_payload_id,
-				pubkey,
-				signature,
-				reputer,
-				topic_id,
-				extra_data,
-				naive_value,
-				combined_value,
-				reputer_request_reputer_nonce
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING id`,
-		payloadId, sql.NullString{msg.ReputerValueBundle.Pubkey, true}, msg.ReputerValueBundle.Signature, msg.ReputerValueBundle.ValueBundle.Reputer,
-		msg.ReputerValueBundle.ValueBundle.TopicID, msg.ReputerValueBundle.ValueBundle.ExtraData, msg.ReputerValueBundle.ValueBundle.NaiveValue,
-		msg.ReputerValueBundle.ValueBundle.CombinedValue,
-		msg.ReputerValueBundle.ValueBundle.ReputerRequestNonce.ReputerNonce.BlockHeight,
-	).Scan(&bundleId)
+
+	// Insert the reputer payload
+	var payloadId uint64
+	err = dbPool.QueryRow(context.Background(), fmt.Sprintf(
+		`INSERT INTO %s (message_height, message_id, sender, reputer_nonce_block_height, topic_id)
+		VALUES ($1, $2, $3, $4, $5) RETURNING id`, TB_REPUTER_PAYLOAD),
+		blockHeight, messageId, msg.Sender, nonce_block_height, topic_id).Scan(&payloadId)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert reputer_bundles")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer_payload")
 		return err
 	}
-	err = insertValueBundle(bundleId, msg.ReputerValueBundle.ValueBundle, TB_BUNDLE_VALUES)
+
+	// Prepare to insert the single value bundle
+	bundle := msg.ReputerValueBundle.ValueBundle
+	_, err = dbPool.Exec(context.Background(), fmt.Sprintf(`
+		INSERT INTO %s (reputer_payload_id, pubkey, signature, reputer, topic_id, extra_data, naive_value, combined_value, reputer_request_reputer_nonce)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`, TB_REPUTER_BUNDLES),
+		payloadId, sql.NullString{msg.ReputerValueBundle.Pubkey, true}, msg.ReputerValueBundle.Signature, bundle.Reputer,
+		bundle.TopicID, bundle.ExtraData, bundle.NaiveValue,
+		bundle.CombinedValue, nonce_block_height)
 	if err != nil {
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer_bundles")
+		return err
+	}
+
+	// Insert the value bundle into the value bundle table
+	err = insertValueBundle(payloadId, bundle, TB_BUNDLE_VALUES)
+	if err != nil {
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert reputer bundle_values")
 		return err
 	}
 
@@ -285,17 +283,17 @@ func insertBulkWorkerPayload(blockHeight uint64, messageId uint64, inf types.Msg
 
 		nonce_block_height, err := strconv.Atoi(inf.Nonce.BlockHeight)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to convert inf.Nonce.BlockHeight to int in insertInferenceForecasts")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inf.Nonce.BlockHeight to int in insertInferenceForecasts")
 			return err
 		}
 		topic_id, err := strconv.Atoi(inf.TopicID)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to convert inf.TopicID to int in insertInferenceForecasts")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inf.TopicID to int in insertInferenceForecasts")
 			return err
 		}
 		block_height, err := strconv.Atoi(bundle.InferenceForecastsBundle.Inference.BlockHeight)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to convert bundle.InferenceForecastsBundle.Inference.BlockHeight to int in insertInferenceForecasts")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert bundle.InferenceForecastsBundle.Inference.BlockHeight to int in insertInferenceForecasts")
 			return err
 		}
 		waitCreation("block_info", "height", strconv.FormatUint(blockHeight, 10))
@@ -317,7 +315,7 @@ func insertWorkerDataBundle(messageId, blockHeight uint64, block_height, topic_i
 
 	inferenceTopicId, err := strconv.Atoi(bundle.InferenceForecastsBundle.Inference.TopicID)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert inference TopicId to int in insertMsgFundTopic")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inference TopicId to int in insertMsgFundTopic")
 		return err
 	}
 	// Insert inference
@@ -339,11 +337,11 @@ func insertWorkerDataBundle(messageId, blockHeight uint64, block_height, topic_i
 			bundle.InferenceForecastsBundle.Inference.Value, bundle.InferenceForecastsBundle.Inference.ExtraData,
 		)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to insert inferences")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert inferences")
 			return err
 		}
 	} else {
-		log.Error().Err(err).Msg("Failed to convert inference value")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inference value")
 		return err
 	}
 	// Insert Forecasts
@@ -365,7 +363,7 @@ func insertWorkerDataBundle(messageId, blockHeight uint64, block_height, topic_i
 			bundle.InferenceForecastsBundle.Forecast.Forecaster,
 		).Scan(&forecastId)
 		if err != nil {
-			log.Error().Err(err).Msg("Failed to insert forecasts")
+			log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert forecasts")
 			return err
 		}
 		log.Info().Msgf("forecast_id: %d", forecastId)
@@ -379,7 +377,7 @@ func insertWorkerDataBundle(messageId, blockHeight uint64, block_height, topic_i
 				forecastId, forecast.Inferer, forecast.Value,
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("Failed to insert forecast_values")
+				log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to insert forecast_values")
 				return err
 			}
 		}
@@ -396,17 +394,17 @@ func insertWorkerPayload(blockHeight uint64, messageId uint64, inf types.MsgInse
 
 	nonce_block_height, err := strconv.Atoi(inf.WorkerDataBundle.Nonce.BlockHeight)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert inf.Nonce.BlockHeight to int in insertInferenceForecasts")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inf.Nonce.BlockHeight to int in insertInferenceForecasts")
 		return err
 	}
 	topic_id, err := strconv.Atoi(inf.WorkerDataBundle.TopicID)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert inf.TopicID to int in insertInferenceForecasts")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert inf.TopicID to int in insertInferenceForecasts")
 		return err
 	}
 	block_height, err := strconv.Atoi(inf.WorkerDataBundle.InferenceForecastsBundle.Inference.BlockHeight)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert bundle.InferenceForecastsBundle.Inference.BlockHeight to int in insertInferenceForecasts")
+		log.Error().Err(err).Uint64("block", blockHeight).Msg("Failed to convert bundle.InferenceForecastsBundle.Inference.BlockHeight to int in insertInferenceForecasts")
 		return err
 	}
 	waitCreation("block_info", "height", strconv.FormatUint(blockHeight, 10))
@@ -441,13 +439,13 @@ func waitCreation(table string, field string, value string) error {
 func insertMsgRegister(height uint64, messageId uint64, msg types.MsgRegister) error {
 	err := insertAddress("allora", sql.NullString{msg.Sender, true}, sql.NullString{"", false}, "")
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert insertMsgRegister insertAddress")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to insert insertMsgRegister insertAddress")
 		return err
 	}
 
 	topId, err := strconv.Atoi(msg.TopicID)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert msg.TopicID to int")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to convert msg.TopicID to int")
 		return err
 	}
 
@@ -470,7 +468,7 @@ func insertMsgRegister(height uint64, messageId uint64, msg types.MsgRegister) e
 		height, messageId, msg.Sender, topId, msg.Owner, msg.LibP2pKey, msg.IsReputer,
 	)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert insertMsgRegister")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to insert insertMsgRegister")
 		return err
 	}
 	return nil
@@ -500,7 +498,7 @@ func insertAddress(t string, address sql.NullString, pub_key sql.NullString, mem
 func insertMsgFundTopic(height uint64, messageId uint64, msg types.MsgFundTopic) error {
 	topId, err := strconv.Atoi(msg.TopicID)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert msg.TopicID to int in insertMsgFundTopic")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to convert msg.TopicID to int in insertMsgFundTopic")
 		return err
 	}
 
@@ -524,7 +522,7 @@ func insertMsgFundTopic(height uint64, messageId uint64, msg types.MsgFundTopic)
 		height, messageId, msg.Sender, topId, msg.Amount, "uallo",
 	)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert insertMsgFundTopic")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to insert insertMsgFundTopic")
 		return err
 	}
 	return nil
@@ -533,12 +531,12 @@ func insertMsgSend(height uint64, messageId uint64, msg types.MsgSend) error {
 
 	err := insertAddress("allora", sql.NullString{msg.FromAddress, true}, sql.NullString{"", false}, "")
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert insertMsgSend insertAddress")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to insert insertMsgSend insertAddress")
 		return err
 	}
 	err = insertAddress("allora", sql.NullString{msg.ToAddress, true}, sql.NullString{"", false}, "")
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to insert insertMsgSend insertAddress")
+		log.Error().Err(err).Uint64("block", height).Msg("Failed to insert insertMsgSend insertAddress")
 		return err
 	}
 	_, err = dbPool.Exec(context.Background(), `


### PR DESCRIPTION
* Fix older binaries for older blocks

it was not working with v3 because the binaries were not well specified. (blocks earlier to migration, block `1004550` ) 
Also it was suboptimal because it had to try first and on failure, run the correct binaries.

* Batch reputer requets

* Fix forecasts insertion! it was inserting inferences twice.

* Batches inserts in rewards and scores. Prepares the ground for networklosses too.