### PR TITLE
Add tx result and tx hash to indexer

### DIFF
--- a/db.go
+++ b/db.go
@@ -230,7 +230,9 @@ func createMessagesTablesSQL() string {
 		type VARCHAR(255),
 		sender VARCHAR(255),
 		data JSONB,
-		hash NUMERIC
+		hash NUMERIC,
+		result JSONB,
+		tx_hash VARCHAR(255)
 	);
 
 	CREATE TABLE IF NOT EXISTS ` + TB_TOPICS + ` (
@@ -648,7 +650,7 @@ func insertBlockInfo(blockInfo DBBlockInfo) error {
 	return nil
 }
 
-func insertMessage(height uint64, mtype string, sender string, data string) (uint64, error) {
+func insertMessage(height uint64, mtype string, sender string, data string, result string, txHash string) (uint64, error) {
 	// Write Topic to the database
 	var id uint64
 	var dataHash = hash(data)
@@ -659,13 +661,17 @@ func insertMessage(height uint64, mtype string, sender string, data string) (uin
 			type,
 			sender,
 			data,
-			hash
-		) VALUES ($1, $2, $3, $4, $5) RETURNING id`,
+			hash,
+			result,
+			tx_hash
+		) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id`,
 		height,
 		mtype,
 		sender,
 		data,
 		dataHash,
+		result,
+		txHash,
 	).Scan(&id)
 	if err != nil {
 		log.Error().Msgf("Failed inserting message, height:%d, hash: %d", height, dataHash)

--- a/go.mod
+++ b/go.mod
@@ -8,20 +8,26 @@ require (
 	github.com/rs/zerolog v1.32.0
 	github.com/schollz/progressbar/v3 v3.14.6
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	golang.org/x/crypto v0.20.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/aws/aws-sdk-go v1.55.5 h1:KKUZBfBoyqy5d3swXyiC7Q76ic40rYcbqH7qjh59kzU=
 github.com/aws/aws-sdk-go v1.55.5/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -18,6 +19,10 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213/go.mod h1:vNUNkEQ1e29fT/6vq2aBdFsgNPmy8qMdSay1npru+Sw=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -31,6 +36,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
+github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.32.0 h1:keLypqrlIjaFsbmJOBdB/qvyF8KEtCWHwobLp5l/mQ0=
 github.com/rs/zerolog v1.32.0/go.mod h1:/7mN4D5sKwJLZQ2b/znpjC3/GQWY/xaDXUM0kKWRHss=
@@ -41,8 +48,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 golang.org/x/crypto v0.20.0 h1:jmAMJJZXr5KiCw05dfYK9QnqaqKLYXijU23lsEdcQqg=
 golang.org/x/crypto v0.20.0/go.mod h1:Xwo95rrVNIoSMx9wa1JroENMToLWn3RNVrTBpLHgZPQ=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
@@ -57,6 +64,8 @@ golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/allora-network/allora-indexer/types"
 	"github.com/spf13/pflag"
 
 	"github.com/rs/zerolog"
@@ -105,6 +106,9 @@ func run() error {
 			},
 			"topicById": {
 				Parts: []string{"{cliApp}", "query", "emissions", "topic", "--node", "{node}", "--output", "json"}, // Requires "{topic}"
+			},
+			"txsByHeight": {
+				Parts: []string{"{cliApp}", "query", "txs", "--query", "tx.height={height}", "--node", "{node}", "--output", "json"},
 			},
 		},
 	}
@@ -281,6 +285,17 @@ func worker(ctx context.Context, wgBlocks *sync.WaitGroup, heightsChan <-chan ui
 
 			log.Info().Msgf("Write height: %d", height)
 
+			txsResults, err := fetchTxsResults(config, height)
+			if err != nil {
+				log.Error().Err(err).Msgf("Worker: Failed to fetchTxsResults, height: %d", height)
+				continue
+			}
+
+			txsResultsMap := make(map[string]types.TxResult)
+			for _, tx := range txsResults {
+				txsResultsMap[tx.Hash] = tx
+			}
+
 			if len(block.Data.Txs) > 0 {
 				log.Info().Msgf("Processing txs at height: %d", height)
 				wgTxs := sync.WaitGroup{}
@@ -290,8 +305,8 @@ func worker(ctx context.Context, wgBlocks *sync.WaitGroup, heightsChan <-chan ui
 					wgTxs.Add(1)
 					go func(encTx string) {
 						defer wgTxs.Done()
-						defer func() { <-txSemaphore }()             // Release the token
-						err := processTx(ctx, &wgTxs, height, encTx) // Pass context and wait group
+						defer func() { <-txSemaphore }()                            // Release the token
+						err := processTx(ctx, &wgTxs, height, encTx, txsResultsMap) // Pass context and wait group
 						if err != nil {
 							log.Error().Err(err).Msgf("Failed to process transaction at height: %d", height)
 						}

--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ func run() error {
 				Parts: []string{"{cliApp}", "query", "emissions", "topic", "--node", "{node}", "--output", "json"}, // Requires "{topic}"
 			},
 			"txsByHeight": {
-				Parts: []string{"{cliApp}", "query", "txs", "--query", "tx.height={height}", "--node", "{node}", "--output", "json"},
+				// Keep {page} as last part to make it easier to update the page number
+				Parts: []string{"{cliApp}", "query", "txs", "--query", "tx.height={height}", "--node", "{node}", "--output", "json", "--page", "{page}"},
 			},
 		},
 	}

--- a/process_tx.go
+++ b/process_tx.go
@@ -736,21 +736,35 @@ func fetchTxsResults(config ClientConfig, height uint64) ([]types.TxResult, erro
 		}
 	}
 
-	// Execute the command with the updated height
-	log.Info().Str("commandName", "txsByHeight").Msgf("Fetching txs at height %s", heightStr)
-	output, err := ExecuteCommand(config.CliApp, config.Node, txsCommand)
-	if err != nil {
-		log.Error().Err(err).Msgf("Failed to fetch txs at height %s", heightStr)
-		return []types.TxResult{}, err
+	page := 1
+	txsResults := []types.TxResult{}
+	for {
+		// Assuming the last part of the command is the page number
+		txsCommand[len(txsCommand)-1] = strconv.Itoa(page)
+
+		// Execute the command with the updated height
+		log.Info().Str("commandName", "txsByHeight").Msgf("Fetching txs at height %s", heightStr)
+		output, err := ExecuteCommand(config.CliApp, config.Node, txsCommand)
+		if err != nil {
+			log.Error().Err(err).Msgf("Failed to fetch txs at height %s", heightStr)
+			return []types.TxResult{}, err
+		}
+
+		var txsResult types.TxSearchResult
+		if err := json.Unmarshal(output, &txsResult); err != nil {
+			log.Error().Err(err).Msg("Failed to unmarshal txs result")
+			return []types.TxResult{}, err
+		}
+
+		txsResults = append(txsResults, txsResult.Results...)
+
+		if txsResult.PageNumber == txsResult.PageTotal {
+			break
+		}
+		page++
 	}
 
-	var txsResult types.TxSearchResult
-	if err := json.Unmarshal(output, &txsResult); err != nil {
-		log.Error().Err(err).Msg("Failed to unmarshal txs result")
-		return []types.TxResult{}, err
-	}
-
-	return txsResult.Results, nil
+	return txsResults, nil
 }
 
 func hashTx(txRaw string, upperCase bool) (string, error) {

--- a/process_tx.go
+++ b/process_tx.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -18,7 +21,7 @@ import (
 const MAX_RETRY int = 3
 const RETRY_PAUSE int = 2
 
-func processTx(ctx context.Context, wg *sync.WaitGroup, height uint64, txData string) error {
+func processTx(ctx context.Context, wg *sync.WaitGroup, height uint64, txData string, txsResults map[string]types.TxResult) error {
 
 	// Use the context to check for cancellation
 	select {
@@ -34,6 +37,27 @@ func processTx(ctx context.Context, wg *sync.WaitGroup, height uint64, txData st
 	txMessage, err := DecodeTx(config, txData, height)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to execute command")
+		return err
+	}
+
+	// Calculate the tx hash
+	txHash, err := hashTx(txData, true)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to hash tx")
+		return err
+	}
+
+	// Get the tx result from the txsResults map
+	txResult, ok := txsResults[txHash]
+	if !ok {
+		log.Error().Msgf("Tx not found in txsResults, height: %d, txHash: %s", height, txHash)
+		return nil
+	}
+
+	// Marshal the tx result
+	jsonResult, err := json.Marshal(txResult)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to marshal txResult")
 		return err
 	}
 
@@ -57,10 +81,15 @@ func processTx(ctx context.Context, wg *sync.WaitGroup, height uint64, txData st
 		}
 
 		var messageId uint64
-		messageId, err = insertMessage(height, mtype, creator, string(mjson))
+		messageId, err = insertMessage(height, mtype, creator, string(mjson), string(jsonResult), txHash)
 		if err != nil {
 			log.Error().Err(err).Msgf("Failed to insertMessage, height: %d", height)
 			return err
+		}
+
+		if txResult.Code != 0 {
+			// If the tx failed, skip the rest of the processing
+			continue
 		}
 
 		switch {
@@ -692,4 +721,56 @@ func insertStakeRequest(height uint64, sender string, topicId string, amount str
 		return err
 	}
 	return nil
+}
+
+func fetchTxsResults(config ClientConfig, height uint64) ([]types.TxResult, error) {
+	// Convert height to string
+	heightStr := strconv.FormatUint(height, 10)
+
+	// Clone the original command and replace {height} placeholder
+	txsCommand := make([]string, len(config.Commands["txsByHeight"].Parts))
+	copy(txsCommand, config.Commands["txsByHeight"].Parts)
+	for i, part := range txsCommand {
+		if part == "tx.height={height}" {
+			txsCommand[i] = "tx.height=" + heightStr
+		}
+	}
+
+	// Execute the command with the updated height
+	log.Info().Str("commandName", "txsByHeight").Msgf("Fetching txs at height %s", heightStr)
+	output, err := ExecuteCommand(config.CliApp, config.Node, txsCommand)
+	if err != nil {
+		log.Error().Err(err).Msgf("Failed to fetch txs at height %s", heightStr)
+		return []types.TxResult{}, err
+	}
+
+	var txsResult types.TxSearchResult
+	if err := json.Unmarshal(output, &txsResult); err != nil {
+		log.Error().Err(err).Msg("Failed to unmarshal txs result")
+		return []types.TxResult{}, err
+	}
+
+	return txsResult.Results, nil
+}
+
+func hashTx(txRaw string, upperCase bool) (string, error) {
+	if txRaw == "" {
+		return "", nil
+	}
+
+	// Decode the txRaw from Base64
+	decoded, err := base64.StdEncoding.DecodeString(txRaw)
+	if err != nil {
+		return "", err
+	}
+
+	// Compute SHA256 hash of the decoded bytes
+	hash := sha256.Sum256(decoded)
+	txHash := hex.EncodeToString(hash[:])
+
+	// Convert to uppercase if required
+	if upperCase {
+		return strings.ToUpper(txHash), nil
+	}
+	return txHash, nil
 }

--- a/process_tx_test.go
+++ b/process_tx_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHashTx(t *testing.T) {
+	tests := []struct {
+		name        string
+		txRaw       string
+		upperCase   bool
+		expected    string
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name:        "Valid Base64, uppercase",
+			txRaw:       "dGVzdFR4", // "testTx" in Base64
+			upperCase:   true,
+			expected:    strings.ToUpper("8C519B7C50548BE414E69281C439E6FD4F6E1DB94D333886BBB523851383251C"),
+			expectError: false,
+			expectedErr: nil,
+		},
+		{
+			name:        "Valid Base64, lowercase",
+			txRaw:       "dGVzdFR4", // "testTx" in Base64
+			upperCase:   false,
+			expected:    "8c519b7c50548be414e69281c439e6fd4f6e1db94d333886bbb523851383251c",
+			expectError: false,
+			expectedErr: nil,
+		},
+		{
+			name:        "Invalid Base64",
+			txRaw:       "!!!invalid!!!",
+			upperCase:   true,
+			expected:    "",
+			expectError: true,
+			expectedErr: base64.CorruptInputError(0),
+		},
+		{
+			name:        "Empty string",
+			txRaw:       "",
+			upperCase:   false,
+			expected:    "",
+			expectError: false,
+			expectedErr: nil,
+		},
+		{
+			name:        "Actual tx, uppercase",
+			txRaw:       "CtwCCtkCCigvZW1pc3Npb25zLnY1Lkluc2VydFdvcmtlclBheWxvYWRSZXF1ZXN0EqwCCithbGxvMXRkZHFlenNyeHMzbDB4ajdyemxrcnQzNWUzeXU3enBxenZqYWxqEvwBCithbGxvMXRkZHFlenNyeHMzbDB4ajdyemxrcnQzNWUzeXU3enBxenZqYWxqEgQIzNVtGBAiPwo9CBAQzNVtGithbGxvMXRkZHFlenNyeHMzbDB4ajdyemxrcnQzNWUzeXU3enBxenZqYWxqIgg5NzE4NC42NipACJ9sncbNjSjGlVPAjsL7pl4+qR6A3LLwMhkfqXnII08IqJXlY+90b3U8st4851ai3HuizlQDOpCgFPn50/purTJCMDNiY2FlMDRjZjBjY2Y4YjA0YjczZGU0MWM0M2EwMWVmZjllMzg1NjI4ZDYyMzMzOWJiMDRhMjM1OTBmM2YwOWQ3Em0KUgpGCh8vY29zbW9zLmNyeXB0by5zZWNwMjU2azEuUHViS2V5EiMKIQO8rgTPDM+LBLc95BxDoB7/njhWKNYjM5uwSiNZDz8J1xIECgIIARjF0AESFwoRCgV1YWxsbxIIMTY5NjA5MDAQwtEJGkBcner4gHSznxX7DQ6o2P+cWhADmfteRX6v9DcSKRGo3m5wEU6trB7jeL/ttFoyFW58jqlxCyABOh6hsCkf08Q6",
+			upperCase:   true,
+			expected:    strings.ToUpper("82F2A53227CF363DFFF731BE4A6644E42107886006E2AF192D416860A4CAF960"),
+			expectError: false,
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := hashTx(tt.txRaw, tt.upperCase)
+			assert.Equal(t, tt.expectedErr, err)
+			if tt.expected == "" {
+				assert.Empty(t, result, "Expected empty string")
+			} else {
+				assert.Equal(t, tt.expected, result, "Hashes do not match")
+			}
+		})
+	}
+}

--- a/types/tx.go
+++ b/types/tx.go
@@ -5,10 +5,10 @@ type Message map[string]interface{}
 type Tx struct {
 	Body struct {
 		Messages                    []Message `json:"messages,omitempty"`
-		Memo                        string `json:"memo,omitempty"`
-		TimeoutHeight               string `json:"timeout_height,omitempty"`
-		ExtensionOptions            []any  `json:"extension_options,omitempty"`
-		NonCriticalExtensionOptions []any  `json:"non_critical_extension_options,omitempty"`
+		Memo                        string    `json:"memo,omitempty"`
+		TimeoutHeight               string    `json:"timeout_height,omitempty"`
+		ExtensionOptions            []any     `json:"extension_options,omitempty"`
+		NonCriticalExtensionOptions []any     `json:"non_critical_extension_options,omitempty"`
 	} `json:"body,omitempty"`
 	AuthInfo struct {
 		SignerInfos []struct {
@@ -35,4 +35,16 @@ type Tx struct {
 		Tip any `json:"tip,omitempty"`
 	} `json:"auth_info,omitempty"`
 	Signatures []string `json:"signatures,omitempty"`
+}
+
+type TxSearchResult struct {
+	Results []TxResult `json:"txs"`
+}
+
+type TxResult struct {
+	Height string `json:"height"`
+	Hash   string `json:"txhash"`
+	Code   int    `json:"code"`
+	Data   string `json:"data"`
+	Log    string `json:"raw_log"`
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -38,13 +38,16 @@ type Tx struct {
 }
 
 type TxSearchResult struct {
-	Results []TxResult `json:"txs"`
+	PageNumber string     `json:"page_number"`
+	PageTotal  string     `json:"page_total"`
+	Results    []TxResult `json:"txs"`
 }
 
 type TxResult struct {
-	Height string `json:"height"`
-	Hash   string `json:"txhash"`
-	Code   int    `json:"code"`
-	Data   string `json:"data"`
-	Log    string `json:"raw_log"`
+	Height    string `json:"height"`
+	Hash      string `json:"txhash"`
+	Code      int    `json:"code"`
+	Data      string `json:"data"`
+	Log       string `json:"raw_log"`
+	CodeSpace string `json:"codespace"`
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v           ✰  Thanks for creating a PR! You're awesome! ✰
v Please note that maintainers will only review those PRs with a completed PR template.
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Purpose of Changes and their Description

This PR adds two new columns to the messages table: results and tx_hash

The first has the result of the execution of the transaction. The second the transaction hash compatible with the chain APIs.

When the result of the transaction is not success, it's only stored at the messages table. See tickets for more details.

## Link(s) to Ticket(s) or Issue(s) resolved by this PR

https://linear.app/alloralabs/issue/PROTO-2983/add-tx-outcome-columns-to-indexer-and-stop-propagating-failed-txs-to

https://linear.app/alloralabs/issue/PROTO-2984/store-tx-hash-as-string-not-as-interpreted-number-in-messages-table

## Are these changes tested and documented?

- [x] If tested, please describe how. If not, why tests are not needed.
- [ ] If documented, please describe where. If not, describe why docs are not needed.
- [ ] Added to `Unreleased` section of `CHANGELOG.md`?

Tested locally processing live testnet blocks.

## Still Left Todo

*Fill this out if this is a Draft PR so others can help.*
